### PR TITLE
Fix jaccard index to reset for each epoch, normalize test images

### DIFF
--- a/configs/dsi.py
+++ b/configs/dsi.py
@@ -8,15 +8,15 @@ KC_MASK_ROOT = os.path.join(DATA_ROOT, "KC-masks/top-structures-masks")
 OUTPUT_ROOT = "/net/projects/cmap/model-outputs"
 
 # model selection
-MODEL = None
-BACKBONE = None
-WEIGHTS = None
+MODEL = "unet"
+BACKBONE = "resnet50"
+WEIGHTS = True
 
 # model hyperparams
 BATCH_SIZE = 32
 PATCH_SIZE = 512
 NUM_CLASSES = 5  # predicting 4 classes + background
 LR = 1e-3
-NUM_WORKERS = 2
-EPOCHS = 1
+NUM_WORKERS = 8
+EPOCHS = 11
 IGNORE_INDEX = 0  # index in images to ignore for jaccard index

--- a/train.py
+++ b/train.py
@@ -58,6 +58,14 @@ if exp_name is None:
 # set output path and exit run if path already exists
 out_root = os.path.join(config.OUTPUT_ROOT, exp_name)
 os.makedirs(out_root, exist_ok=False)
+
+# create directory for output images
+train_images_root = os.path.join(out_root, "train-images")
+test_image_root = os.path.join(out_root, "test-images")
+os.mkdir(train_images_root)
+os.mkdir(test_image_root)
+
+# open tensorboard writer
 writer = SummaryWriter(out_root)
 
 # copy training script and config to output directory
@@ -113,17 +121,22 @@ device = (
 print(f"Using {device} device")
 
 # create the model
-model = SegmentationModel(num_classes=config.NUM_CLASSES).model.to(device)
+model = SegmentationModel(
+    model=config.MODEL,
+    backbone=config.BACKBONE,
+    num_classes=config.NUM_CLASSES,
+    weights=config.WEIGHTS,
+).model.to(device)
 print(model)
 
 # set the loss function, metrics, and optimizer
 loss_fn = JaccardLoss(mode="multiclass", classes=config.NUM_CLASSES)
-train_metric = MulticlassJaccardIndex(
+train_jaccard = MulticlassJaccardIndex(
     num_classes=config.NUM_CLASSES,
     ignore_index=config.IGNORE_INDEX,
     average="micro",
 ).to(device)
-test_metric = MulticlassJaccardIndex(
+test_jaccard = MulticlassJaccardIndex(
     num_classes=config.NUM_CLASSES,
     ignore_index=config.IGNORE_INDEX,
     average="micro",
@@ -235,20 +248,21 @@ def train_setup(
     # remove channel dim from y (req'd for loss func)
     y_squeezed = y[:, 0, :, :].squeeze()
 
-    # plot first image with more than 1 class in first batch
+    # plot first batch
     if batch == 0:
-        i = 0
-        while len(y[i].unique()) < 2 and i < config.BATCH_SIZE - 1:
-            i += 1
-
-        plot_tensors = {
-            "image": sample["image"][i],
-            "mask": sample["mask"][i],
-            "augmented_image": denormalize(X)[i].cpu(),
-            "augmented_mask": y[i].cpu(),
-        }
-        sample_fname = os.path.join(out_root, f"train_sample-{epoch}.png")
-        plot_from_tensors(plot_tensors, sample_fname)
+        save_dir = os.path.join(train_images_root, f"epoch-{epoch}")
+        os.mkdir(save_dir)
+        for i in range(config.BATCH_SIZE):
+            plot_tensors = {
+                "image": sample["image"][i],
+                "mask": sample["mask"][i],
+                "augmented_image": denormalize(X)[i].cpu(),
+                "augmented_mask": y[i].cpu(),
+            }
+            sample_fname = os.path.join(
+                save_dir, f"train_sample-{epoch}.{i}.png"
+            )
+            plot_from_tensors(plot_tensors, sample_fname, "grid")
 
     return X, y_squeezed
 
@@ -257,12 +271,13 @@ def train(
     dataloader: DataLoader,
     model: Module,
     loss_fn: Module,
-    metric: Metric,
+    jaccard: Metric,
     optimizer: Optimizer,
     epoch: int,
 ):
     num_batches = len(dataloader)
     model.train()
+    jaccard.reset()
     train_loss = 0
     for batch, sample in enumerate(dataloader):
         # images = sample["image"]
@@ -289,9 +304,9 @@ def train(
         outputs = model(X)
         loss = loss_fn(outputs, y)
 
-        # update metric
+        # update jaccard index
         preds = outputs.argmax(dim=1)
-        metric(preds, y)
+        jaccard.update(preds, y)
 
         # backpropagation
         loss.backward()
@@ -303,21 +318,22 @@ def train(
             loss, current = loss.item(), (batch + 1)
             print(f"loss: {loss:>7f}  [{current:>5d}/{num_batches:>5d}]")
     train_loss /= num_batches
-    final_metric = metric.compute()
+    final_jaccard = jaccard.compute()
     writer.add_scalar("Loss/train", train_loss, epoch)
-    writer.add_scalar("Metric/train", final_metric, epoch)
-    print(f"Jaccard Index: {final_metric}")
+    writer.add_scalar("Jaccard/train", final_jaccard, epoch)
+    print(f"Jaccard Index: {final_jaccard}")
 
 
 def test(
     dataloader: DataLoader,
     model: Module,
     loss_fn: Module,
-    metric: Metric,
+    jaccard: Metric,
     epoch: int,
 ):
     num_batches = len(dataloader)
     model.eval()
+    jaccard.reset()
     test_loss = 0
     with torch.no_grad():
         for batch, sample in enumerate(dataloader):
@@ -345,6 +361,7 @@ def test(
             # y_squeezed = y.squeeze(1)
 
             X = sample["image"].to(device)
+            X = normalize(X)
             y = sample["mask"].to(device)
             y_squeezed = y[:, 0, :, :].squeeze()
 
@@ -354,40 +371,39 @@ def test(
 
             # update metric
             preds = outputs.argmax(dim=1)
-            metric(preds, y_squeezed)
+            jaccard.update(preds, y_squeezed)
 
             # add test loss to rolling total
             test_loss += loss.item()
 
-            # plot first image with more than 1 class in first batch
+            # plot first batch
             if batch == 0:
-                i = 0
-                while len(y[i].unique()) < 2 and i < config.BATCH_SIZE - 1:
-                    i += 1
-
-                plot_tensors = {
-                    "image": sample["image"][i],
-                    "ground_truth": sample["mask"][i],
-                    "inference": preds[i].cpu(),
-                }
-                sample_fname = os.path.join(
-                    out_root, f"test_sample-{epoch}.png"
-                )
-                plot_from_tensors(plot_tensors, sample_fname)
+                save_dir = os.path.join(test_image_root, f"epoch-{epoch}")
+                os.mkdir(save_dir)
+                for i in range(config.BATCH_SIZE):
+                    plot_tensors = {
+                        "image": sample["image"][i],
+                        "ground_truth": sample["mask"][i],
+                        "inference": preds[i].cpu(),
+                    }
+                    sample_fname = os.path.join(
+                        save_dir, f"test_sample-{epoch}.{i}.png"
+                    )
+                    plot_from_tensors(plot_tensors, sample_fname, "row")
     test_loss /= num_batches
-    final_metric = metric.compute()
+    final_jaccard = jaccard.compute()
     writer.add_scalar("Loss/test", test_loss, epoch)
-    writer.add_scalar("Metric/test", final_metric, epoch)
+    writer.add_scalar("Jaccard/test", final_jaccard, epoch)
     print(
-        f"Test Error: \n Jaccard index: {final_metric:>7f}, "
+        f"Test Error: \n Jaccard index: {final_jaccard:>7f}, "
         + f"Avg loss: {test_loss:>7f} \n"
     )
 
 
 for t in range(config.EPOCHS):
     print(f"Epoch {t + 1}\n-------------------------------")
-    train(train_dataloader, model, loss_fn, train_metric, optimizer, t + 1)
-    test(test_dataloader, model, loss_fn, test_metric, t + 1)
+    train(train_dataloader, model, loss_fn, train_jaccard, optimizer, t + 1)
+    test(test_dataloader, model, loss_fn, test_jaccard, t + 1)
 print("Done!")
 writer.close()
 

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -39,7 +39,9 @@ def plot_from_sample(sample: DefaultDict[str, Any], save_root: str):
     plt.savefig(fname)
 
 
-def plot_from_tensors(sample: Dict[str, Tensor], save_path: str):
+def plot_from_tensors(
+    sample: Dict[str, Tensor], save_path: str, mode: str = "grid"
+):
     """
     Plots a sample from the training dataset and saves to provided file path.
 
@@ -51,22 +53,42 @@ def plot_from_tensors(sample: Dict[str, Tensor], save_path: str):
 
     save_path : str
         The path to save the plot to
-    """
-    _, axs = plt.subplots(
-        int(round(len(sample.keys()) / 2)), 2, figsize=(10, 10)
-    )
 
-    for i, (name, tensor) in enumerate(sample.items()):
-        ax = axs[i // 2][i % 2]
-        if len(tensor.shape) == 2:
-            ax.imshow(tensor)
-        elif len(tensor.shape) == 3:
-            ax.imshow(tensor[0])
-        else:
-            raise ValueError(
-                "Expected tensor with dimensions h x w or c x h x w"
-            )
-        ax.set_title(name)
-        ax.axis("off")
+    mode : str
+        Either 'grid' or 'row' for orientation of images on plot
+    """
+    if mode == "grid":
+        _, axs = plt.subplots(
+            int(round(len(sample.keys()) / 2)), 2, figsize=(10, 10)
+        )
+        for i, (name, tensor) in enumerate(sample.items()):
+            ax = axs[i // 2][i % 2]
+            if len(tensor.shape) == 2:
+                ax.imshow(tensor)
+            elif len(tensor.shape) == 3:
+                ax.imshow(tensor[0])
+            else:
+                raise ValueError(
+                    "Expected tensor with dimensions h x w or c x h x w"
+                )
+            ax.set_title(name)
+            ax.axis("off")
+    elif mode == "row":
+        _, axs = plt.subplots(1, len(sample.keys()), figsize=(10, 5))
+        for i, (name, tensor) in enumerate(sample.items()):
+            ax = axs[i]
+            if len(tensor.shape) == 2:
+                ax.imshow(tensor)
+            elif len(tensor.shape) == 3:
+                ax.imshow(tensor[0])
+            else:
+                raise ValueError(
+                    "Expected tensor with dimensions h x w or c x h x w"
+                )
+            ax.set_title(name)
+            ax.axis("off")
+    else:
+        raise ValueError("Invalid mode")
 
     plt.savefig(save_path)
+    plt.close()


### PR DESCRIPTION
The primary changes made were to `train.py`. The first was to fix the jaccard index, which needs to be reset for each epoch (one line of code each for `train()` and `test()`). The second was to add normalization to the images in `test()` prior to running inference on them. This is required since the model is being trained on normalized images and thus requires normalized images for testing.

Other small changes were made to the plotting:
`train.py`
- save down a copy of all images from the first batch of each epoch (for train and test), and store them in a specific sub-directory of the output root

`plot.py`
- implemented functionality in `plot_from_tensors()` for user to choose between "grid" and "row" output types for images. This allows for training images to use a "grid" orientation and test images to use a "row" orientation