### PR TITLE
Isolate the OUTPUT_ROOT by user

### DIFF
--- a/configs/dsi.py
+++ b/configs/dsi.py
@@ -5,7 +5,7 @@ DATA_ROOT = "/net/projects/cmap/data"
 KC_SHAPE_ROOT = os.path.join(DATA_ROOT, "kane-county-data")
 KC_IMAGE_ROOT = os.path.join(DATA_ROOT, "KC-images")
 KC_MASK_ROOT = os.path.join(DATA_ROOT, "KC-masks/separate-masks")
-OUTPUT_ROOT = "/net/projects/cmap/model-outputs"
+OUTPUT_ROOT = f"/net/projects/cmap/workspaces/{os.environ['USER']}"
 
 # model selection
 MODEL = "deeplabv3+"


### PR DESCRIPTION
This makes it so everyone's run output is going to a dedicated directory for their user, which should make it easier to see your own experiments.