### PR TITLE
Add configurable context

### DIFF
--- a/configs/dsi.py
+++ b/configs/dsi.py
@@ -28,6 +28,7 @@ DATASET_STD = [
 ]
 BATCH_SIZE = 16
 PATCH_SIZE = 512
+CONTEXT_SIZE = 64
 NUM_CLASSES = 5  # predicting 4 classes + background
 LR = 1e-5
 NUM_WORKERS = 8

--- a/data/kcv.py
+++ b/data/kcv.py
@@ -59,6 +59,7 @@ class KaneCounty(GeoDataset):
         layer: int,
         label_col: str,
         labels: dict[int, str],
+        context_size: int,
         dest_crs: Optional[CRS] = None,
         res: float = 0.0001,
     ) -> None:
@@ -70,6 +71,7 @@ class KaneCounty(GeoDataset):
             label_col: name of the dataset property that has the label to be
                 rasterized into the mask
             labels: a dictionary containing a label mapping for masks
+            context_size: the maximum amount of context preserved around shapes
             dest_crs: the coordinate reference system (CRS) to convert to
             res: resolution of the dataset in units of CRS
 
@@ -89,7 +91,14 @@ class KaneCounty(GeoDataset):
         for _, row in gdf.iterrows():
             minx, miny, maxx, maxy = row["geometry"].bounds
             mint, maxt = 0, sys.maxsize
-            coords = (minx, maxx, miny, maxy, mint, maxt)
+            coords = (
+                minx - context_size,
+                maxx + context_size,
+                miny - context_size,
+                maxy + context_size,
+                mint,
+                maxt,
+            )
             self.index.insert(i, coords, row)
             i += 1
         if i == 0:
@@ -100,6 +109,7 @@ class KaneCounty(GeoDataset):
         self.labels = labels
         self.colors = {i: self.all_colors[i] for i in labels.values()}
         self.labels_inverse = {v: k for k, v in labels.items()}
+        self.context_size = context_size
         self._crs = dest_crs
         self._res = res
 


### PR DESCRIPTION
This pull request adds configurable context size to shapes smaller than the patch. The main changes are:
1. Adjusted the KaneCounty dataset index to include the context around the shapes.
2. Padded the space between context and patch edges with 0.

<img width="743" alt="image" src="https://github.com/dsi-clinic/2024-winter-cmap/assets/81978021/d13cece2-9e9e-4f21-90df-5ec7e57b3989">
