### PR TITLE
Enhance data augmentation with configurable pipelines and modes

### DIFF
--- a/configs/dsi.py
+++ b/configs/dsi.py
@@ -54,10 +54,10 @@ IMAGE_AUG_INDICES = [
     1,  # Brightness
     2,  # Gaussian Noise
     3,  # Gaussian Blur
-    4,  # Plasma Brightness
+    # 4,  # Plasma Brightness
     5,  # Saturation
-    6,  # Channel Shuffle
-    7,  # Gamma
+    # 6,  # Channel Shuffle
+    # 7,  # Gamma
 ]
 AUG_PARAMS = {
     "rotation_degrees": 360,
@@ -72,7 +72,8 @@ AUG_PARAMS = {
     "shade_quantity": (0.0, 0.05),
     "gamma": (0.8, 1.2),
 }
-AUG_MODE = "random"  # all or random
+SPATIAL_AUG_MODE = "all"  # all or random
+COLOR_AUG_MODE = "random"  # all or random
 
 # KaneCounty data
 KC_SHAPE_FILENAME = "KC_StormwaterDataJan2024.gdb.zip"

--- a/train.py
+++ b/train.py
@@ -320,7 +320,8 @@ def train_setup(
     sample: DefaultDict[str, Any],
     epoch: int,
     batch: int,
-    aug_mode,
+    spatial_aug_mode,
+    color_aug_mode,
     spatial_augs,
     color_augs,
     train_images_root,
@@ -364,7 +365,9 @@ def train_setup(
     # scale both img and mask to range of [0, 1] (req'd for augmentations)
     X = scale(X)
 
-    X_aug, y_aug = apply_augs(spatial_augs, color_augs, X, y, aug_mode)
+    X_aug, y_aug = apply_augs(
+        spatial_augs, color_augs, X, y, spatial_aug_mode, color_aug_mode
+    )
 
     # denormalize mask to reset to index tensor (req'd for loss func)
     y = y_aug.type(torch.int64)
@@ -422,7 +425,8 @@ def train_epoch(
     writer,
     spatial_augs,
     color_augs,
-    aug_mode,
+    spatial_aug_mode,
+    color_aug_mode,
 ) -> None:
     """
     Executes a training step for the model
@@ -456,7 +460,8 @@ def train_epoch(
             sample,
             epoch,
             batch,
-            aug_mode,
+            spatial_aug_mode,
+            color_aug_mode,
             spatial_augs,
             color_augs,
             train_images_root,
@@ -658,7 +663,8 @@ def train(
             writer,
             spatial_augs,
             color_augs,
-            config.AUG_MODE,
+            config.SPATIAL_AUG_MODE,
+            config.COLOR_AUG_MODE,
         )
 
         test_loss, t_jaccard = test(

--- a/utils/transforms.py
+++ b/utils/transforms.py
@@ -99,7 +99,13 @@ def create_augmentation_pipelines(
 
 
 def apply_augs(
-    spatial_transforms, color_transforms, image, mask, mode, rgb_channels=None
+    spatial_transforms,
+    color_transforms,
+    image,
+    mask,
+    spatial_mode,
+    color_mode,
+    rgb_channels=None,
 ):
     """
     Apply spatial and color augs to an image and its corresponding mask.
@@ -127,15 +133,18 @@ def apply_augs(
     rgb_mask[rgb_channels] = True
 
     # Random mode: pick random number and set of augmentations to apply
-    if mode == "random":
+    if spatial_mode == "random":
         spatial_augmentations = random.sample(
             spatial_transforms, k=random.randint(1, len(spatial_transforms))
         )
+    else:
+        spatial_augmentations = spatial_transforms
+
+    if color_mode == "random":
         color_augmentations = random.sample(
             color_transforms, k=random.randint(1, len(color_transforms))
         )
     else:
-        spatial_augmentations = spatial_transforms
         color_augmentations = color_transforms
 
     # Create a pipeline for spatial augmentations and apply them to the image and mask


### PR DESCRIPTION
This PR introduces an enhanced data augmentation system with the following features:

1. Configurable augmentation pipelines:
   - Added config options `SPATIAL_AUG_INDICES` and `IMAGE_AUG_INDICES` to select specific spatial and color augmentations.
   - Created separate lists for spatial and color augmentations in `create_augmentation_pipelines`.
   - Augmentation parameters can be adjusted in the `AUG_PARAMS` config dictionary.
2. Augmentation modes:
   - Introduced `AUG_MODE` config option to choose between 'random' and 'all' augmentation modes. In 'random' mode, a random number and set of augmentations are applied. In 'all' mode, all selected augmentations are applied.
3. Improved color augmentations:
   - Color augmentations are now applied only to the image's RGB channels. Non-RGB channels are separated, and the RGB channels undergo color augmentations before recombining.
4. Handling of zero-padded areas:
   - Generated a mask to identify non-padded areas in the augmented image.
   - Ensured that color augmentations do not affect zero-padded regions, fixing the issue described in Trello #122.


This PR aims to provide more flexibility and control over the data augmentation. It also addresses the regression I introduced in PR #55 (Trello #124) and fixes Trello #123 by properly separating spatial and color augmentations. Finally, it fixes Trello #120 by moving all aug-related options to the config, enhancing reproducibility.

Note that this will slightly break HP tuning, but adapting the tuning config for the new run config format should be an easy fix.


