### PR TITLE
Add RandomResizedCrop

### DIFF
--- a/configs/dsi.py
+++ b/configs/dsi.py
@@ -45,6 +45,7 @@ SPATIAL_AUG_INDICES = [
     3,  # Affine
     4,  # Elastic
     5,  # Perspective
+    6,  # ResizedCrop
 ]
 
 # only applied to images-- not masks
@@ -60,6 +61,7 @@ IMAGE_AUG_INDICES = [
 ]
 AUG_PARAMS = {
     "rotation_degrees": 360,
+    "resized_crop_size": (PATCH_SIZE, PATCH_SIZE),
     "contrast_limit": 0.2,
     "brightness_limit": 0.2,
     "gaussian_noise_prob": 0.2,

--- a/utils/transforms.py
+++ b/utils/transforms.py
@@ -51,6 +51,9 @@ def create_augmentation_pipelines(
             kernel_size=(63, 63), sigma=(32.0, 32.0), alpha=(1.0, 1.0), p=0.5
         ),
         K.RandomPerspective(distortion_scale=0.5, p=0.5),
+        K.RandomResizedCrop(
+            size=aug_params["resized_crop_size"], scale=(0.08, 1.0)
+        ),
     ]
 
     # Define all possible color augmentations


### PR DESCRIPTION
This pull request adds the `RandomResizedCrop` augmentation from the Kornia library to our list of spatial augmentations. This augmentation randomly crops and resizes the input image to a specified size, which can help improve the model's robustness to scale and aspect ratio variations.