### PR TITLE
Update configs based on tuning results

### DIFF
--- a/configs/dsi.py
+++ b/configs/dsi.py
@@ -9,7 +9,7 @@ OUTPUT_ROOT = f"/net/projects/cmap/workspaces/{os.environ['USER']}"
 
 # model selection
 MODEL = "deeplabv3+"
-BACKBONE = "resnet50"
+BACKBONE = "resnet101"
 # check backbone, mean, and std when setting weights
 WEIGHTS = True
 


### PR DESCRIPTION
Tuned `LR`, `batch_size`, and `patch_size` based on the best-performing model in `models-performance.md`. Got the highest average test jaccard index of `0.6154` across 5 trials with the updated configs.