### PR TITLE
Add dropout

### DIFF
--- a/configs/config.py
+++ b/configs/config.py
@@ -23,6 +23,9 @@ BACKBONE = "resnet101"
 # check backbone, mean, and std when setting weights
 WEIGHTS = True
 
+# dropout rate
+DROPOUT = 0.3
+
 # model hyperparams
 DATASET_MEAN = [
     0.3281668683529412,

--- a/fcn.py
+++ b/fcn.py
@@ -74,4 +74,3 @@ class FCN(Module):
         x = self.backbone(x)
         x = self.last(x)
         return x
-

--- a/fcn.py
+++ b/fcn.py
@@ -1,0 +1,78 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# 
+
+"""
+Simple fully convolutional neural network (FCN) implementations that integrates
+dropout
+"""
+
+import torch.nn as nn
+from torch import Tensor
+from torch.nn.modules import Module
+
+
+class FCN(Module):
+    """A simple 5 layer FCN with leaky relus and 'same' padding."""
+
+    def __init__(
+        self, 
+        in_channels: int, 
+        classes: int, 
+        num_filters: int = 64, 
+        dropout: float = 0.3,
+    ) -> None:
+        """Initializes the 5 layer FCN model.
+
+        Args:
+            in_channels: Number of input channels that the model will expect
+            classes: Number of filters in the final layer
+            num_filters: Number of filters in each convolutional layer
+            dropout: Dropout rate used when training the model
+        """
+        super().__init__()
+
+        conv1 = nn.modules.Conv2d(
+            in_channels, num_filters, kernel_size=3, stride=1, padding=1
+        )
+        conv2 = nn.modules.Conv2d(
+            num_filters, num_filters, kernel_size=3, stride=1, padding=1
+        )
+        conv3 = nn.modules.Conv2d(
+            num_filters, num_filters, kernel_size=3, stride=1, padding=1
+        )
+        conv4 = nn.modules.Conv2d(
+            num_filters, num_filters, kernel_size=3, stride=1, padding=1
+        )
+        conv5 = nn.modules.Conv2d(
+            num_filters, num_filters, kernel_size=3, stride=1, padding=1
+        )
+
+        self.backbone = nn.modules.Sequential(
+            conv1,
+            nn.modules.LeakyReLU(inplace=True),
+            nn.Dropout(p=dropout),
+            conv2,
+            nn.modules.LeakyReLU(inplace=True),
+            nn.Dropout(p=dropout),
+            conv3,
+            nn.modules.LeakyReLU(inplace=True),
+            nn.Dropout(p=dropout),
+            conv4,
+            nn.modules.LeakyReLU(inplace=True),
+            nn.Dropout(p=dropout),
+            conv5,
+            nn.modules.LeakyReLU(inplace=True),
+            nn.Dropout(p=dropout),
+        )
+
+        self.last = nn.modules.Conv2d(
+            num_filters, classes, kernel_size=1, stride=1, padding=0
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward pass of the model."""
+        x = self.backbone(x)
+        x = self.last(x)
+        return x
+

--- a/fcn.py
+++ b/fcn.py
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.
-# 
+# Licensed under the MIT License. 
 
 """Simple fully convolutional neural network (FCN) implementations that integrates
 dropout

--- a/fcn.py
+++ b/fcn.py
@@ -2,8 +2,7 @@
 # Licensed under the MIT License.
 # 
 
-"""
-Simple fully convolutional neural network (FCN) implementations that integrates
+"""Simple fully convolutional neural network (FCN) implementations that integrates
 dropout
 """
 
@@ -16,10 +15,10 @@ class FCN(Module):
     """A simple 5 layer FCN with leaky relus and 'same' padding."""
 
     def __init__(
-        self, 
-        in_channels: int, 
-        classes: int, 
-        num_filters: int = 64, 
+        self,
+        in_channels: int,
+        classes: int,
+        num_filters: int = 64,
         dropout: float = 0.3,
     ) -> None:
         """Initializes the 5 layer FCN model.

--- a/model.py
+++ b/model.py
@@ -9,11 +9,11 @@ import importlib
 from pathlib import Path
 
 import segmentation_models_pytorch as smp
-from fcn import FCN
-from torchgeo.models import FCN, get_weight
+from torchgeo.models import get_weight
 from torchgeo.trainers import utils
 from torchvision.models._api import WeightsEnum
-
+ 
+from fcn import FCN
 
 class SegmentationModel:
     """This class represents a segmentation model for image segmentation tasks.
@@ -147,7 +147,7 @@ class SegmentationModel:
     def __getweights__(self):
         """Returns the weights of the model"""
         return self.weights
-    
+
     def __getdropout__(self):
         """Returns the dropout rate of the model"""
         return self.dropout

--- a/model.py
+++ b/model.py
@@ -9,6 +9,7 @@ import importlib
 from pathlib import Path
 
 import segmentation_models_pytorch as smp
+from fcn import FCN
 from torchgeo.models import FCN, get_weight
 from torchgeo.trainers import utils
 from torchvision.models._api import WeightsEnum
@@ -62,6 +63,7 @@ class SegmentationModel:
         self.num_classes = model_config["num_classes"]
         self.weights = model_config["weights"]
         self.in_channels = model_config.get("in_channels")
+        self.dropout = model_config.get("dropout", 0.3)
         if self.in_channels is None:
             self.in_channels = 5
         if model != "fcn":
@@ -103,6 +105,10 @@ class SegmentationModel:
                     encoder_weights="swsl" if self.weights is True else None,
                     in_channels=self.in_channels,
                     classes=self.num_classes,
+                    aux_params={
+                        "classes": self.num_classes,
+                        "dropout": self.dropout,
+                    },
                 )
 
             elif model == "deeplabv3+":
@@ -111,23 +117,28 @@ class SegmentationModel:
                     encoder_weights=("imagenet" if self.weights is True else None),
                     in_channels=self.in_channels,
                     classes=self.num_classes,
+                    aux_params={
+                        "classes": self.num_classes,
+                        "dropout": self.dropout,
+                    },
                 )
 
-            elif model == "fcn":
-                self.model = FCN(
-                    in_channels=self.in_channels,
-                    classes=self.num_classes,
-                    num_filters=3,
-                )
+        elif model == "fcn":
+            self.model = FCN(
+                in_channels=self.in_channels,
+                classes=self.num_classes,
+                num_filters=3,
+                dropout=self.dropout,
+            )
 
-            else:
-                raise ValueError(
-                    f"Model type '{model}' is not valid. "
-                    "Currently, only supports 'unet', 'deeplabv3+' and 'fcn'."
-                )
-            if self.weights and self.weights is not True:
-                self.model.encoder.load_state_dict(state_dict)
-            self.model.in_channels = self.in_channels
+        else:
+            raise ValueError(
+                f"Model type '{model}' is not valid. "
+                "Currently, only supports 'unet', 'deeplabv3+' and 'fcn'."
+            )
+        if self.weights and self.weights is not True:
+            self.model.encoder.load_state_dict(state_dict)
+        self.model.in_channels = self.in_channels
 
     def __getbackbone__(self):
         """Returns the backbone of the model"""
@@ -136,3 +147,7 @@ class SegmentationModel:
     def __getweights__(self):
         """Returns the weights of the model"""
         return self.weights
+    
+    def __getdropout__(self):
+        """Returns the dropout rate of the model"""
+        return self.dropout

--- a/model.py
+++ b/model.py
@@ -12,8 +12,9 @@ import segmentation_models_pytorch as smp
 from torchgeo.models import get_weight
 from torchgeo.trainers import utils
 from torchvision.models._api import WeightsEnum
- 
+
 from fcn import FCN
+
 
 class SegmentationModel:
     """This class represents a segmentation model for image segmentation tasks.

--- a/train.py
+++ b/train.py
@@ -259,6 +259,7 @@ def create_model():
         "backbone": config.BACKBONE,
         "num_classes": config.NUM_CLASSES,
         "weights": config.WEIGHTS,
+        "dropout": config.DROPOUT,
     }
 
     model = SegmentationModel(model_configs).model.to(MODEL_DEVICE)
@@ -540,6 +541,10 @@ def train_epoch(
 
         # compute prediction error
         outputs = model(x)
+
+        if isinstance(outputs, tuple):
+            outputs = outputs[0]
+
         loss = compute_loss(
             model,
             outputs,


### PR DESCRIPTION
**Description**
This PR introduces dropout to our three models. This feature is a crucial part of our project's roadmap as it addresses issues with overfitting.

- Added dropout parameter to model config
- Created new fcn module to implement dropout
- Added dropout argument to "Unet," "DeepLabV3Plus," and "FCN" models
- Added if-statement in training phase to check if model(x) returns a tuple. This addresses the issue that occurs when using the "Unet" and "DeepLabV3Plus" models as model(x) returns a tuple when dropout is implemented.

**Additional Note**
After bringing model.py and configs/config.py into ruff compliance, the code causes an error, which roots from configs/config.py. After testing with the original configs/config.py file, the code runs without error. Judging by the error message and debugging, I was able to determine that the following line in configs/config.py does not behave in the same way the previous version of code worked.

`KC_IMAGE_ROOT = Path(DATA_ROOT) / "KC-images"`

<img width="931" alt="Screenshot 2024-11-03 at 20 17 50" src="https://github.com/user-attachments/assets/bd1de07b-b89a-41c6-89af-ce6596e0fe5a">