### PR TITLE
Convert Path object into string

### DIFF
--- a/configs/config.py
+++ b/configs/config.py
@@ -9,13 +9,13 @@ from pathlib import Path
 
 # data paths
 DATA_ROOT = "/net/projects/cmap/data"
-KC_SHAPE_ROOT = Path(DATA_ROOT) / "kane-county-data"
-KC_IMAGE_ROOT = Path(DATA_ROOT) / "KC-images"
-KC_RIVER_ROOT = Path(DATA_ROOT) / "KC-river-images"
+KC_SHAPE_ROOT = str(Path(DATA_ROOT) / "kane-county-data")
+KC_IMAGE_ROOT = str(Path(DATA_ROOT) / "KC-images")
+KC_RIVER_ROOT = str(Path(DATA_ROOT) / "KC-river-images")
 KC_DEM_ROOT = None
-# KC_DEM_ROOT = Path(KC_SHAPE_ROOT) / "KC_DEM_2017"
-KC_MASK_ROOT = Path(DATA_ROOT) / "KC-masks/separate-masks"
-OUTPUT_ROOT = Path("/net/projects/cmap/workspaces/") / f"{os.environ['USER']}"
+# KC_DEM_ROOT = str(Path(KC_SHAPE_ROOT) / "KC_DEM_2017")
+KC_MASK_ROOT = str(Path(DATA_ROOT) / "KC-masks/separate-masks")
+OUTPUT_ROOT = str(Path("/net/projects/cmap/workspaces/") / f"{os.environ['USER']}")
 
 # model selection
 MODEL = "deeplabv3+"


### PR DESCRIPTION
**Description**
This PR addresses the type error that is caused by the Path objects in the configs/config.py file. This error began occurring after bringing codebase into ruff compliance.

**Changes Made**
- All Path obejcts in the configs/config.py file were converted to a string

**Additional Notes**
- Unlike the Path objects in the config.py file, those in the train.py were left as they were as changing them into a string object was causing type errors.