### PR TITLE
Multi gpu processing in train.py

### DIFF
--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: pip

--- a/.github/workflows/main.workflow.yml
+++ b/.github/workflows/main.workflow.yml
@@ -25,10 +25,10 @@ jobs:
           cache-dependency-path: |
             requirements.txt
       - name: Run pre-commit
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.1
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with pre-commit
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1

--- a/configs/config.py
+++ b/configs/config.py
@@ -27,6 +27,8 @@ WEIGHTS = True
 
 DROPOUT = 0.0
 
+MULTIPROCESSING = True
+
 # model hyperparams
 # mean/std of imagenet for pretrained model
 DATASET_MEAN = [

--- a/train.py
+++ b/train.py
@@ -9,6 +9,8 @@ import argparse
 import datetime
 import importlib.util
 import logging
+import multiprocessing
+import os
 import random
 import shutil
 import sys
@@ -1275,6 +1277,8 @@ def one_trial(exp_n, num, wandb_tune, images, labels, split_rate, args):
 if __name__ == "__main__":
     # Check GPU availability; if GPU available, run on compute node, else exit
     check_gpu_availability()
+    num_gpus = torch.cuda.device_count()
+    print("The number of GPUs available is:", num_gpus)
 
     # import config and experiment name from runtime args
     parser = argparse.ArgumentParser(
@@ -1323,14 +1327,18 @@ if __name__ == "__main__":
     config.DEBUG_MODE = args.debug
 
     exp_name, split, wandb_tune, num_trials = arg_parsing(args)
+    num_trials = int(num_trials)
 
     logging.info("Using %s device", MODEL_DEVICE)
 
     images, labels = initialize_dataset(config)
 
-    def run_trials():
+    def run_trials(trial_id, gpu_id):
         """Running training for multiple trials"""
         # Extract config dictionary from module
+
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+        torch.cuda.set_device(0)
 
         if wandb_tune:
             wandb.init(project="CMAP")
@@ -1342,12 +1350,19 @@ if __name__ == "__main__":
         train_ious = []
         test_ious = []
 
-        for num in range(num_trials):
+        if config.MULTIPROCESSING:
             train_iou, test_iou = one_trial(
-                exp_name, num, wandb_tune, images, labels, split, args
+                exp_name, trial_id, wandb_tune, images, labels, split, args
             )
             train_ious.append(round(float(train_iou), 3))
             test_ious.append(round(float(test_iou), 3))
+        else:
+            for num in range(num_trials):
+                train_iou, test_iou = one_trial(
+                    exp_name, num, wandb_tune, images, labels, split, args
+                )
+                train_ious.append(round(float(train_iou), 3))
+                test_ious.append(round(float(test_iou), 3))
 
         test_average = mean(test_ious)
         train_average = mean(train_ious)
@@ -1372,4 +1387,15 @@ if __name__ == "__main__":
             wandb.run.summary["average_test_jaccard_index"] = test_average
             wandb.finish()
 
-    run_trials()
+    if config.MULTIPROCESSING:
+        processes = []
+        for trial_id in range(int(args.num_trials)):
+            gpu_id = trial_id % num_gpus
+            p = multiprocessing.Process(target=run_trials, args=(trial_id, gpu_id))
+            p.start()
+            processes.append(p)
+
+        for p in processes:
+            p.join()
+    else:
+        run_trials(0, 0)

--- a/train.py
+++ b/train.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 from pathlib import Path
 from statistics import mean, stdev
 from typing import Any
+from argparse import Namespace
 
 import kornia.augmentation as K
 import torch
@@ -1278,36 +1279,37 @@ def one_trial(exp_n, num, wandb_tune, images, labels, split_rate, args):
 
 
 def run_trials(
-    trial_id, gpu_id, config_dict, args_dict, split, exp_name, wandb_tune, num_trials
+    trial_id, gpu_id, args_dict, split, exp_name, wandb_tune, num_trials
 ):
     """Running training for multiple trials"""
-    # import torch
-    # os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
-
     torch.cuda.set_device(gpu_id)
 
+    global config
+    config = importlib.import_module(args_dict["config"])
     images, labels = initialize_dataset(config)
+
+    args = Namespace(**args_dict)
 
     if wandb_tune:
         wandb.init(project="CMAP")
         print("wandb taken over config")
     else:
         # Initialize wandb with default configuration but disable logging
-        wandb.init(project="CMAP", config=config_dict, mode="disabled")
+        wandb.init(project="CMAP", config=config, mode="disabled")
 
     train_ious = []
     test_ious = []
 
     if config.MULTIPROCESSING:
         train_iou, test_iou = one_trial(
-            exp_name, trial_id, wandb_tune, images, labels, split, args_dict
+            exp_name, trial_id, wandb_tune, images, labels, split, args
         )
         train_ious.append(round(float(train_iou), 3))
         test_ious.append(round(float(test_iou), 3))
     else:
         for num in range(num_trials):
             train_iou, test_iou = one_trial(
-                exp_name, num, wandb_tune, images, labels, split, args_dict
+                exp_name, num, wandb_tune, images, labels, split, args
             )
             train_ious.append(round(float(train_iou), 3))
             test_ious.append(round(float(test_iou), 3))
@@ -1382,14 +1384,7 @@ if __name__ == "__main__":
 
     config = importlib.import_module(args.config)
 
-    config_dict = {
-        "EPOCHS": 1 if args.debug else config.EPOCHS,
-        "MULTIPROCESSING": config.MULTIPROCESSING,
-        "DEBUG_MODE": args.debug,
-    }
-
     args_dict = vars(args)  # make argparse Namespace pickle-safe
-    print(config_dict)
     print(args_dict)
     exp_name, split, wandb_tune, num_trials = arg_parsing(args)
     num_trials = int(num_trials)
@@ -1405,7 +1400,6 @@ if __name__ == "__main__":
                 args=(
                     trial_id,
                     gpu_id,
-                    config_dict,
                     args_dict,
                     split,
                     exp_name,
@@ -1420,5 +1414,5 @@ if __name__ == "__main__":
             p.join()
     else:
         run_trials(
-            0, 0, config_dict, args_dict, split, exp_name, wandb_tune, num_trials
+            0, 0, args_dict, split, exp_name, wandb_tune, num_trials
         )


### PR DESCRIPTION
Multiprocessing implemented within train.py. config.MULTIPROCESSING must be set to True to run on multiple GPUs. Request as many GPUs from the machine as trials you desire to run. If less GPUs than num_trials, they will run in sequence on individual GPUs as normal.

Still needed:
- Need to test --debug function still
- Need to test logging behavior
- Need to include documentation in README.md